### PR TITLE
Returning waitPeriod info in the authTypes endpoint

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -71,7 +71,9 @@ func (f *faucet) registerHandlers(api *apirest.API) {
 func (f *faucet) authTypesHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	data := &AuthTypes{
 		AuthTypes: f.authTypes,
+		Wait:      uint64(f.waitPeriod.Seconds()),
 	}
+
 	return ctx.Send(new(HandlerResponse).Set(data).MustMarshall(), apirest.HTTPstatusOK)
 }
 

--- a/handlers.go
+++ b/handlers.go
@@ -70,8 +70,8 @@ func (f *faucet) registerHandlers(api *apirest.API) {
 // Returns the list of supported auth types
 func (f *faucet) authTypesHandler(_ *apirest.APIdata, ctx *httprouter.HTTPContext) error {
 	data := &AuthTypes{
-		AuthTypes: f.authTypes,
-		Wait:      uint64(f.waitPeriod.Seconds()),
+		AuthTypes:   f.authTypes,
+		WaitSeconds: uint64(f.waitPeriod.Seconds()),
 	}
 
 	return ctx.Send(new(HandlerResponse).Set(data).MustMarshall(), apirest.HTTPstatusOK)

--- a/types.go
+++ b/types.go
@@ -5,6 +5,7 @@ import "fmt"
 // AuthTypes is a struct to return the supported authentication types.
 type AuthTypes struct {
 	AuthTypes map[string]uint64 `json:"auth"`
+	Wait      uint64            `json:"wait"`
 }
 
 var errAddressAlreadyFunded = fmt.Errorf("address already funded")

--- a/types.go
+++ b/types.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // AuthTypes is a struct to return the supported authentication types.
 type AuthTypes struct {
-	AuthTypes map[string]uint64 `json:"auth"`
-	Wait      uint64            `json:"wait"`
+	AuthTypes   map[string]uint64 `json:"auth"`
+	WaitSeconds uint64            `json:"waitSeconds"`
 }
 
 var errAddressAlreadyFunded = fmt.Errorf("address already funded")


### PR DESCRIPTION
Added waitPeriod info to the already called /authTypes endpoint.
Only adding a field in the current structure, shouldn't break anyone using the endpoint.